### PR TITLE
add bzip2 package, which is not included in CentOS 7

### DIFF
--- a/attributes/rhel.rb
+++ b/attributes/rhel.rb
@@ -25,6 +25,7 @@ return unless %w(rhel fedora).include?(node['platform_family'])
 
 # The list of packages to install on redhat-based systems
 default['phantomjs']['packages'] = [
+  'bzip2',
   'fontconfig',
-  'freetype',
+  'freetype'
 ]


### PR DESCRIPTION
```
172.16.0.6     ================================================================================
172.16.0.6     Error executing action `run` on resource 'execute[phantomjs-install]'
172.16.0.6     ================================================================================
172.16.0.6
172.16.0.6     Mixlib::ShellOut::ShellCommandFailed
172.16.0.6     ------------------------------------
172.16.0.6     Expected process to exit with [0], but received '2'
172.16.0.6     ---- Begin output of tar -xvjf /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/ ----
172.16.0.6     STDOUT:
172.16.0.6     STDERR: tar (child): bzip2: Cannot exec: No such file or directory
172.16.0.6     tar (child): Error is not recoverable: exiting now
172.16.0.6     tar: Child returned status 2
172.16.0.6     tar: Error is not recoverable: exiting now
172.16.0.6     ---- End output of tar -xvjf /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/ ----
172.16.0.6     Ran tar -xvjf /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/ returned 2
172.16.0.6
172.16.0.6     Resource Declaration:
172.16.0.6     ---------------------
172.16.0.6     # In /var/chef/cache/cookbooks/phantomjs/recipes/source.rb
172.16.0.6
172.16.0.6      53: execute 'phantomjs-install' do
172.16.0.6      54:   command   "tar -xvjf #{src_dir}/#{basename}.tar.bz2 -C /usr/local/"
172.16.0.6      55:   action    :nothing
172.16.0.6      56:   notifies  :create, 'link[phantomjs-link]', :immediately
172.16.0.6      57: end
172.16.0.6      58:
172.16.0.6
172.16.0.6     Compiled Resource:
172.16.0.6     ------------------
172.16.0.6     # Declared in /var/chef/cache/cookbooks/phantomjs/recipes/source.rb:53:in `from_file'
172.16.0.6
172.16.0.6     execute("phantomjs-install") do
172.16.0.6       action [:nothing]
172.16.0.6       retries 0
172.16.0.6       retry_delay 2
172.16.0.6       default_guard_interpreter :execute
172.16.0.6       command "tar -xvjf /usr/local/src/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/"
172.16.0.6       backup 5
172.16.0.6       returns 0
172.16.0.6       user nil
172.16.0.6       declared_type :execute
172.16.0.6       cookbook_name "phantomjs"
172.16.0.6       recipe_name "source"
172.16.0.6     end
172.16.0.6
172.16.0.6     System Info:
172.16.0.6     ------------
172.16.0.6     chef_version=12.21.3
172.16.0.6     platform=centos
172.16.0.6     platform_version=7.3.1611
172.16.0.6     ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
172.16.0.6     program_name=chef-client worker: ppid=1149;start=14:54:23;
172.16.0.6     executable=/opt/chef/bin/chef-client
172.16.0.6
```